### PR TITLE
fix: correct documentation URLs in i18n files

### DIFF
--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -1,6 +1,6 @@
 {
   "app_title": "🔥 FireBalance Planner",
-  "app_caption": "Your personal tool for Financial Independence, Retire Early. For concepts and usage guide, please refer to [User Guide](https://github.com/freedeaths/FIRE-Balance/docs/usage_en.md)",
+  "app_caption": "Your personal tool for Financial Independence, Retire Early. For concepts and usage guide, please refer to [User Guide](https://github.com/freedeaths/FIRE-Balance/blob/main/docs/usage_en.md)",
   "navigation": "Navigation",
   "language": "Language",
   "session_management": "Session Management",

--- a/shared/i18n/ja.json
+++ b/shared/i18n/ja.json
@@ -1,6 +1,6 @@
 {
   "app_title": "🔥 FIRE(Financial Independence, Retire Early)資産プランナー",
-  "app_caption": "あなたの経済的自立と早期退職のための個人ツール。概念と使用方法については [使用ガイド](https://github.com/freedeaths/FIRE-Balance/docs/usage_ja.md) をご参照ください",
+  "app_caption": "あなたの経済的自立と早期退職のための個人ツール。概念と使用方法については [使用ガイド](https://github.com/freedeaths/FIRE-Balance/blob/main/docs/usage_ja.md) をご参照ください",
   "navigation": "ナビゲーション",
   "language": "言語",
   "session_management": "セッション管理",

--- a/shared/i18n/zh-CN.json
+++ b/shared/i18n/zh-CN.json
@@ -1,6 +1,6 @@
 {
   "app_title": "🔥 FIRE(Financial Independence, Retire Early)财务规划器",
-  "app_caption": "您的个人财务自由提前退休规划工具。概念和使用方法请参考 [使用说明](https://github.com/freedeaths/FIRE-Balance/docs/usage_cn.md)",
+  "app_caption": "您的个人财务自由提前退休规划工具。概念和使用方法请参考 [使用说明](https://github.com/freedeaths/FIRE-Balance/blob/main/docs/usage_cn.md)",
   "navigation": "导航",
   "language": "语言",
   "session_management": "会话管理",


### PR DESCRIPTION
## Summary
- Fix missing '/blob/main' in documentation links for all languages
- Ensure URLs point to correct documentation files in main branch  
- Affects English, Chinese, and Japanese translations

## Files Changed
- : Fixed usage_en.md URL
- : Fixed usage_cn.md URL  
- : Fixed usage_ja.md URL

## Testing
URLs now correctly point to:
- https://github.com/freedeaths/FIRE-Balance/blob/main/docs/usage_en.md
- https://github.com/freedeaths/FIRE-Balance/blob/main/docs/usage_cn.md
- https://github.com/freedeaths/FIRE-Balance/blob/main/docs/usage_ja.md