### PR TITLE
feat(ts): add interval-based items and Stage2 column override reset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# AGENTS.md
+
+Project-level guidance for contributors and coding agents.
+
+## Overview
+
+FIRE Balance is a monorepo:
+- `implementations/typescript/` (maintained): React + TypeScript web app (primary)
+- `implementations/python/` (legacy): no new features; may lag behind schema/UI
+- `shared/`: shared assets (notably i18n JSON)
+- `docs/`: documentation
+
+## TypeScript architecture (maintained)
+
+Working dir: `implementations/typescript/`
+- `src/core/`: calculation engine + planner logic (domain layer)
+- `src/stores/`: Zustand state (planner data, overrides, import/export)
+- `src/components/`: UI (Stage1/Stage2/Stage3 content, tables, charts)
+- `src/services/`: orchestration glue (e.g. running calculations)
+- `src/types/` + `src/types/ui.ts`: plan schema + UI↔core conversions
+- i18n: `shared/i18n/{en,zh-CN,ja}.json` (consumed via `@shared` alias)
+
+## Development commands
+
+CI uses Node.js 20 for TypeScript and Python 3.12 for Python.
+
+TypeScript:
+- Dev: `npm -C implementations/typescript run dev`
+- Type-check: `npm -C implementations/typescript run type-check`
+- Lint/format: `npm -C implementations/typescript run lint`, `npm -C implementations/typescript run format`
+- Tests: `npm -C implementations/typescript test`
+- Build: `npm -C implementations/typescript run build`
+- One-shot checks: `npm -C implementations/typescript run prepare`
+
+Python (legacy):
+- Only touch if necessary; keep changes minimal.
+- Quality gates still exist in CI and pre-commit for `implementations/python/`.
+
+## Quality gates (before pushing / opening a PR)
+
+Pre-commit (repo-level):
+- Install once: `pre-commit install`
+- Run: `pre-commit run --all-files`
+
+Match GitHub Actions (TypeScript Checks workflow):
+- `npm -C implementations/typescript ci`
+- `npm -C implementations/typescript run format:check`
+- `npm -C implementations/typescript run lint`
+- `npm -C implementations/typescript run type-check`
+- `npm -C implementations/typescript test`
+- `npm -C implementations/typescript run build`
+
+Notes:
+- If you change `shared/i18n/*.json`, keep keys consistent across languages; JSON validity is enforced by pre-commit and CI.
+- Deployment to Cloudflare Pages is gated by the TypeScript Checks workflow on `main`.

--- a/README.md
+++ b/README.md
@@ -25,13 +25,14 @@ FIRE Balance Calculator provides a scientific approach to FIRE planning by break
 
 This project implements the FIRE calculator in multiple programming languages:
 
-- **Python Implementation**: Streamlit-based web application with comprehensive calculation engine
-- **React + TypeScript Implementation**: Modern web application with Tailwind CSS
+- **Python Implementation (legacy)**: `implementations/python/` is no longer actively maintained; it may fall behind the latest plan schema and UI behavior.
+- **React + TypeScript Implementation (maintained)**: Primary implementation going forward (`implementations/typescript/`).
 - **Rust WASM Implementation**: Not currently planned, calculations are not complex enough
 
 ## 🚀 Quick Start
 
 ### Python Version
+Note: `implementations/python/` is legacy and will not receive new features. Prefer the React + TypeScript version unless you specifically need the Python CLI.
 
 #### Command Line Interface (CLI)
 
@@ -62,7 +63,13 @@ python cli/fire_planner.py --output results.json
 
 ### React + TypeScript Version
 
-...
+```bash
+cd implementations/typescript
+npm install
+npm run dev
+```
+
+See `implementations/typescript/README.md` for details.
 
 ## 📖 Core Concepts
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -25,13 +25,14 @@ FIRE Balance計算機は、複雑なプロセスを管理可能な段階に分�
 
 このプロジェクトは複数のプログラミング言語でFIRE計算機を実装します：
 
-- **Python実装**：包括的な計算エンジンを持つStreamlitベースのWebアプリケーション
-- **React + TypeScript実装**：Tailwind CSSを使用したモダンなWebアプリケーション
+- **Python実装（legacy）**：`implementations/python/` は今後更新しません。最新のプラン schema / UI 振る舞いに追従しない可能性があります。
+- **React + TypeScript実装（維持管理中）**：今後の主要実装（`implementations/typescript/`）。
 - **Rust WASM実装**：現在計画されていません、計算が十分複雑ではありません
 
 ## 🚀 クイックスタート
 
 ### Pythonバージョン
+注意：`implementations/python/` は legacy のため新機能追加は行いません。特に理由がなければ React + TypeScript 版を推奨します。
 
 #### コマンドラインインターフェース（CLI）
 
@@ -62,7 +63,13 @@ python cli/fire_planner.py --output results.json
 
 ### React + TypeScriptバージョン
 
-...
+```bash
+cd implementations/typescript
+npm install
+npm run dev
+```
+
+詳細は `implementations/typescript/README.md` を参照してください。
 
 ## 📖 核心概念
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -25,13 +25,14 @@ FIRE Balance 计算器通过将复杂的财务规划过程分解为可管理的�
 
 本项目使用多种编程语言实现 FIRE 计算器：
 
-- **Python 实现**：基于 Streamlit 的 Web 应用，具有全面的计算引擎
-- **React + TypeScript 实现**：使用 Tailwind CSS 的现代 Web 应用
+- **Python 实现（legacy）**：`implementations/python/` 后续不再更新，可能会落后于最新的计划 schema 和 UI 行为。
+- **React + TypeScript 实现（持续维护）**：后续主要维护版本（`implementations/typescript/`）。
 - **Rust WASM 实现**：未在计划中，目前计算不复杂
 
 ## 🚀 快速开始
 
 ### Python 版本
+注意：`implementations/python/` 为 legacy，不会再新增功能。除非你明确需要 Python CLI，否则建议使用 React + TypeScript 版本。
 
 #### 命令行界面 (CLI)
 
@@ -62,7 +63,13 @@ python cli/fire_planner.py --output results.json
 
 ### React + TypeScript 版本
 
-...
+```bash
+cd implementations/typescript
+npm install
+npm run dev
+```
+
+更多说明见 `implementations/typescript/README.md`。
 
 ## 📖 核心概念
 

--- a/implementations/python/README.md
+++ b/implementations/python/README.md
@@ -1,0 +1,5 @@
+## Status
+
+`implementations/python/` is **legacy** and is no longer actively maintained. New features and behavior changes will land in the TypeScript implementation (`implementations/typescript/`) going forward.
+
+The Python CLI may still work, but it can fall behind the latest plan schema and UI behavior.

--- a/implementations/typescript/src/components/charts/IncomeExpenseBreakdownChart.tsx
+++ b/implementations/typescript/src/components/charts/IncomeExpenseBreakdownChart.tsx
@@ -26,6 +26,7 @@ import {
   ResponsiveFullscreenChartWrapper,
   useMobileDisplay,
 } from './ResponsiveFullscreenChartWrapper';
+import { computeAnnualItemAmountAtAge } from '../../utils/projection';
 // 移除 Override 导入，因为我们不再在这里处理override
 
 // =============================================================================
@@ -94,11 +95,10 @@ const IncomeExpenseBreakdownChart = React.memo(
       const startAge = Math.max(currentAge, 25);
       const endAge = Math.max(fireAge + 10, 70);
 
-      let rawInflationRate = userProfile.inflation_rate;
-      if (rawInflationRate === undefined || rawInflationRate === null) {
-        rawInflationRate = 3.0;
+      let inflationRatePct = userProfile.inflation_rate;
+      if (inflationRatePct === undefined || inflationRatePct === null) {
+        inflationRatePct = 3.0;
       }
-      const inflationRate = rawInflationRate / 100;
 
       const data: IncomeExpenseBreakdownData[] = [];
       const allItems = [...incomeItems, ...expenseItems];
@@ -108,42 +108,12 @@ const IncomeExpenseBreakdownChart = React.memo(
         const row: IncomeExpenseBreakdownData = { age, year };
 
         allItems.forEach(item => {
-          if (age >= item.start_age && age <= (item.end_age || 999)) {
-            const yearsFromStart = age - item.start_age;
-            let baseAmount = item.after_tax_amount_per_period;
-
-            if (item.frequency === 'recurring') {
-              if (item.time_unit === 'monthly') {
-                baseAmount = baseAmount * 12;
-              }
-            } else if (item.frequency === 'one-time') {
-              if (yearsFromStart !== 0) {
-                row[item.id] = 0;
-                return;
-              }
-            }
-
-            const isIncomeItem = incomeItems.some(inc => inc.id === item.id);
-            let currentAmount: number;
-
-            if (isIncomeItem) {
-              const itemGrowthRate = (item.annual_growth_rate || 0) / 100;
-              currentAmount =
-                baseAmount * Math.pow(1 + itemGrowthRate, yearsFromStart);
-            } else {
-              const itemGrowthRate = (item.annual_growth_rate || 0) / 100;
-              const totalGrowthRate = inflationRate + itemGrowthRate;
-              currentAmount =
-                baseAmount * Math.pow(1 + totalGrowthRate, yearsFromStart);
-            }
-
-            // 支出项目设为负值，收入项目保持正值
-            row[item.id] = isIncomeItem
-              ? Math.round(currentAmount)
-              : -Math.round(currentAmount);
-          } else {
-            row[item.id] = 0;
-          }
+          row[item.id] = computeAnnualItemAmountAtAge(
+            item,
+            age,
+            inflationRatePct,
+            'negative'
+          );
         });
 
         data.push(row);

--- a/implementations/typescript/src/components/contents/Stage1Content.tsx
+++ b/implementations/typescript/src/components/contents/Stage1Content.tsx
@@ -29,6 +29,9 @@ import {
   IconChartPie,
   IconWallet,
   IconInfoCircle,
+  IconAlertTriangle,
+  IconCircleCheck,
+  IconCircleX,
 } from '@tabler/icons-react';
 import { usePlannerStore } from '../../stores/plannerStore';
 import { useAppStore } from '../../stores/appStore';
@@ -587,6 +590,18 @@ export function Stage1Content() {
     );
 
     const isValidTotal = Math.abs(totalAllocation - 100) < 0.01;
+    const weightedReturn = calculateWeightedReturn();
+    const inflationRate =
+      userProfile.inflation_rate ?? DEFAULT_USER_PROFILE.inflation_rate;
+    const hasAnyReturnValue = portfolio.asset_classes.some(
+      asset =>
+        asset.expected_return !== undefined && asset.expected_return !== null
+    );
+    const shouldWarnBelowInflation =
+      totalAllocation > 0 &&
+      hasAnyReturnValue &&
+      Number.isFinite(inflationRate) &&
+      weightedReturn + 1e-9 < inflationRate;
 
     return (
       <Card shadow='sm' padding='lg' radius='md'>
@@ -696,45 +711,49 @@ export function Stage1Content() {
           ))}
         </Grid>
 
-        {/* 总计和验证 - 一行平衡布局 */}
-        <div
-          style={{
-            marginTop: '16px',
-            padding: '12px',
-            backgroundColor: isValidTotal ? '#e6f7e6' : '#ffe6e6',
-            borderRadius: '6px',
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            flexWrap: 'wrap',
-            gap: '12px',
-          }}
-        >
-          {/* 左侧：验证状态 */}
-          <div>
-            {isValidTotal ? (
-              <Text c='green' size='sm' fw={600}>
-                ✅{' '}
-                {t('allocation_total', { total: totalAllocation.toFixed(1) })}
-              </Text>
+        <Alert
+          icon={
+            isValidTotal ? (
+              <IconCircleCheck size={20} />
             ) : (
-              <Text c='red' size='sm' fw={600}>
-                ❌{' '}
-                {t('allocation_total', { total: totalAllocation.toFixed(1) })}
-              </Text>
-            )}
-          </div>
+              <IconCircleX size={20} />
+            )
+          }
+          color={isValidTotal ? 'green' : 'red'}
+          variant='light'
+          mt='md'
+        >
+          <Group justify='space-between' align='center' gap='sm' wrap='wrap'>
+            <Text size='sm' fw={600}>
+              {t('allocation_total', { total: totalAllocation.toFixed(1) })}
+            </Text>
 
-          {/* 右侧：加权收益率 */}
-          <Group gap='sm'>
-            <Text size='sm' c='dimmed'>
-              {t('portfolio_expected_return')}:
-            </Text>
-            <Text size='lg' fw={700}>
-              {calculateWeightedReturn().toFixed(2)}%
-            </Text>
+            <Group gap='sm'>
+              <Text size='sm' c='dimmed'>
+                {t('portfolio_expected_return')}:
+              </Text>
+              <Text size='lg' fw={700}>
+                {weightedReturn.toFixed(2)}%
+              </Text>
+            </Group>
           </Group>
-        </div>
+        </Alert>
+
+        {shouldWarnBelowInflation && (
+          <Alert
+            icon={<IconAlertTriangle size={20} />}
+            color='yellow'
+            variant='light'
+            mt='sm'
+          >
+            <Text size='sm'>
+              {t('portfolio_return_below_inflation_warning', {
+                portfolioReturn: weightedReturn.toFixed(2),
+                inflationRate: inflationRate.toFixed(2),
+              })}
+            </Text>
+          </Alert>
+        )}
       </Card>
     );
   };

--- a/implementations/typescript/src/components/contents/Stage1Content.tsx
+++ b/implementations/typescript/src/components/contents/Stage1Content.tsx
@@ -38,8 +38,11 @@ import { useAppStore } from '../../stores/appStore';
 import { FormField } from '../forms/FormField';
 import { IncomeExpenseForm } from '../forms/IncomeExpenseForm';
 import { getI18n } from '../../core/i18n';
-import type { UserProfile } from '../../types';
-import { DEFAULT_PORTFOLIO } from '../../types';
+import {
+  DEFAULT_PORTFOLIO,
+  DEFAULT_USER_PROFILE,
+  type UserProfile,
+} from '../../types';
 
 export function Stage1Content() {
   // Store hooks

--- a/implementations/typescript/src/components/forms/IncomeExpenseForm.tsx
+++ b/implementations/typescript/src/components/forms/IncomeExpenseForm.tsx
@@ -8,7 +8,7 @@
  * - 与Stage2的Handsontable集成
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import {
   Card,
   Title,
@@ -114,6 +114,12 @@ export function IncomeExpenseForm({
   showTemplates = true,
   templates,
 }: IncomeExpenseFormProps) {
+  const ALLOWED_MONTHLY_INTERVAL_PERIODS = [1, 2, 3, 4, 6] as const;
+  const allowedMonthlyIntervalSet = useMemo(
+    () => new Set<number>(ALLOWED_MONTHLY_INTERVAL_PERIODS),
+    []
+  );
+
   // Store hooks
   const plannerStore = usePlannerStore();
   const { currentLanguage } = useAppStore();
@@ -206,6 +212,22 @@ export function IncomeExpenseForm({
       newErrors.frequency = t('validation.required');
     }
 
+    if (formData.frequency !== 'one_time') {
+      const interval = formData.interval_periods;
+      if (interval === undefined || interval === null) {
+        newErrors.interval_periods = t('validation.required');
+      } else if (!Number.isFinite(interval) || interval <= 0) {
+        newErrors.interval_periods = t('validation.must_be_positive');
+      } else if (Math.floor(interval) !== interval) {
+        newErrors.interval_periods = t('validation.must_be_integer');
+      } else if (
+        formData.frequency === 'monthly' &&
+        !allowedMonthlyIntervalSet.has(interval)
+      ) {
+        newErrors.interval_periods = t('validation.invalid_monthly_interval');
+      }
+    }
+
     if (!formData.start_age || formData.start_age < 0) {
       newErrors.start_age = t('validation.invalid_age');
     }
@@ -237,6 +259,7 @@ export function IncomeExpenseForm({
     setEditingItem(null);
     setFormData({
       frequency: 'annual', // 保留频率默认值，因为这是必选项
+      interval_periods: 1,
     });
     setErrors({});
     setModalOpen(true);
@@ -256,11 +279,25 @@ export function IncomeExpenseForm({
   const handleSave = () => {
     if (!validateForm()) return;
 
+    const normalizeIntervalPeriods = (): number => {
+      const raw = formData.interval_periods;
+      const normalized =
+        raw === undefined || raw === null ? 1 : Math.max(1, Math.floor(raw));
+
+      if (formData.frequency === 'monthly') {
+        return allowedMonthlyIntervalSet.has(normalized) ? normalized : 1;
+      }
+
+      return normalized;
+    };
+
     const completeItem: UIIncomeExpenseItem = {
       id: editingItem?.id || uuidv4(),
       name: formData.name!,
       after_tax_amount_per_period: formData.after_tax_amount_per_period!,
       frequency: formData.frequency!,
+      interval_periods:
+        formData.frequency === 'one_time' ? 1 : normalizeIntervalPeriods(),
       growth_rate: formData.growth_rate!,
       start_age: formData.start_age!,
       end_age: formData.end_age!,
@@ -315,6 +352,7 @@ export function IncomeExpenseForm({
     setFormData({
       ...template,
       id: uuidv4(),
+      interval_periods: template.interval_periods ?? 1,
       start_age: dynamicStartAge,
       end_age: dynamicEndAge,
     });
@@ -335,7 +373,44 @@ export function IncomeExpenseForm({
   const canUseTemplates = getCurrentAge() !== null;
 
   const handleFieldChange = (field: keyof UIIncomeExpenseItem, value: any) => {
-    setFormData(prev => ({ ...prev, [field]: value }));
+    setFormData(prev => {
+      if (field !== 'frequency') {
+        return { ...prev, [field]: value };
+      }
+
+      const nextFrequency = value as UIItemFrequency | undefined;
+
+      if (nextFrequency === 'one_time') {
+        return { ...prev, frequency: nextFrequency, interval_periods: 1 };
+      }
+
+      if (nextFrequency === 'monthly') {
+        const rawInterval = prev.interval_periods;
+        const normalizedInterval =
+          typeof rawInterval === 'number'
+            ? Math.max(1, Math.floor(rawInterval))
+            : 1;
+        const nextInterval = allowedMonthlyIntervalSet.has(normalizedInterval)
+          ? normalizedInterval
+          : 1;
+        return {
+          ...prev,
+          frequency: nextFrequency,
+          interval_periods: nextInterval,
+        };
+      }
+
+      const rawInterval = prev.interval_periods;
+      const normalizedInterval =
+        typeof rawInterval === 'number'
+          ? Math.max(1, Math.floor(rawInterval))
+          : 1;
+      return {
+        ...prev,
+        frequency: nextFrequency,
+        interval_periods: normalizedInterval,
+      };
+    });
 
     // Clear error when user starts typing
     if (errors[field as string]) {
@@ -380,6 +455,15 @@ export function IncomeExpenseForm({
                   <Text size='xs' c='dimmed'>
                     Age {item.start_age} - {item.end_age}
                   </Text>
+
+                  {item.frequency !== 'one_time' && (
+                    <Text size='xs' c='dimmed'>
+                      {t('item_interval')}: {item.interval_periods}{' '}
+                      {item.frequency === 'annual'
+                        ? t('interval_years')
+                        : t('interval_months')}
+                    </Text>
+                  )}
                 </Group>
               </Stack>
 
@@ -436,6 +520,7 @@ export function IncomeExpenseForm({
                   <Table.Th>{t('item_name')}</Table.Th>
                   <Table.Th>{t('item_amount')}</Table.Th>
                   <Table.Th>{t('item_frequency')}</Table.Th>
+                  <Table.Th>{t('item_interval')}</Table.Th>
                   <Table.Th>{t('item_growth_rate')}</Table.Th>
                   <Table.Th>{t('item_start_age')}</Table.Th>
                   <Table.Th>{t('item_end_age')}</Table.Th>
@@ -458,6 +543,17 @@ export function IncomeExpenseForm({
                       <Badge size='sm' variant='light'>
                         {t(item.frequency)}
                       </Badge>
+                    </Table.Td>
+                    <Table.Td>
+                      <Text>
+                        {item.frequency === 'one_time'
+                          ? '-'
+                          : `${item.interval_periods} ${
+                              item.frequency === 'annual'
+                                ? t('interval_years')
+                                : t('interval_months')
+                            }`}
+                      </Text>
                     </Table.Td>
                     <Table.Td>
                       <Text>{item.growth_rate}%</Text>
@@ -553,6 +649,47 @@ export function IncomeExpenseForm({
                 onChange={value => handleFieldChange('frequency', value)}
               />
             </Grid.Col>
+
+            {formData.frequency !== 'one_time' && (
+              <Grid.Col span={{ base: 12, sm: 6 }}>
+                <FormField
+                  type={formData.frequency === 'monthly' ? 'select' : 'number'}
+                  name='interval_periods'
+                  label={`${t('item_interval')} (${
+                    formData.frequency === 'annual'
+                      ? t('interval_years')
+                      : t('interval_months')
+                  })`}
+                  value={
+                    formData.frequency === 'monthly'
+                      ? formData.interval_periods?.toString()
+                      : formData.interval_periods
+                  }
+                  options={
+                    formData.frequency === 'monthly'
+                      ? ALLOWED_MONTHLY_INTERVAL_PERIODS.map(v => ({
+                          value: v.toString(),
+                          label: v.toString(),
+                        }))
+                      : undefined
+                  }
+                  min={formData.frequency === 'monthly' ? undefined : 1}
+                  precision={formData.frequency === 'monthly' ? undefined : 0}
+                  required
+                  error={errors.interval_periods}
+                  onChange={value =>
+                    handleFieldChange(
+                      'interval_periods',
+                      formData.frequency === 'monthly'
+                        ? value
+                          ? Number(value)
+                          : undefined
+                        : value
+                    )
+                  }
+                />
+              </Grid.Col>
+            )}
 
             <Grid.Col span={{ base: 12, sm: 6 }}>
               <FormField

--- a/implementations/typescript/src/components/tables/Stage2FinancialTable.tsx
+++ b/implementations/typescript/src/components/tables/Stage2FinancialTable.tsx
@@ -19,6 +19,7 @@ import 'handsontable/dist/handsontable.full.min.css';
 import { usePlannerStore } from '../../stores/plannerStore';
 import { useAppStore } from '../../stores/appStore';
 import { getI18n } from '../../core/i18n';
+import { computeAnnualItemAmountAtAge } from '../../utils/projection';
 // 移除未使用的导入
 // import type { IncomeExpenseItem } from '../../types';
 
@@ -196,6 +197,9 @@ export function Stage2FinancialTable({
   const addOverride = usePlannerStore(state => state.addOverride);
   const updateOverride = usePlannerStore(state => state.updateOverride);
   const removeOverride = usePlannerStore(state => state.removeOverride);
+  const removeOverridesByItemId = usePlannerStore(
+    state => state.removeOverridesByItemId
+  );
   const updateProjectionData = usePlannerStore(
     state => state.updateProjectionData
   );
@@ -302,11 +306,10 @@ export function Stage2FinancialTable({
     const startAge = currentAge;
     const endAge = userProfile.life_expectancy || 85;
 
-    let rawInflationRate = userProfile.inflation_rate;
-    if (rawInflationRate === undefined || rawInflationRate === null) {
-      rawInflationRate = 3.0;
+    let inflationRatePct = userProfile.inflation_rate;
+    if (inflationRatePct === undefined || inflationRatePct === null) {
+      inflationRatePct = 3.0;
     }
-    const inflationRate = rawInflationRate / 100;
 
     const data: Stage2ProjectionRow[] = [];
     const allItems = [...incomeItems, ...expenseItems];
@@ -316,41 +319,12 @@ export function Stage2FinancialTable({
       const row: Stage2ProjectionRow = { year, age };
 
       allItems.forEach(item => {
-        if (age >= item.start_age && age <= (item.end_age || 999)) {
-          const yearsFromStart = age - item.start_age;
-          let baseAmount = item.after_tax_amount_per_period;
-
-          if (item.frequency === 'recurring') {
-            if (item.time_unit === 'monthly') {
-              baseAmount = baseAmount * 12;
-            }
-          } else if (item.frequency === 'one-time') {
-            if (yearsFromStart !== 0) {
-              row[item.id as string] = 0;
-              return;
-            }
-          }
-
-          const isIncomeItem = incomeItems.some(
-            (inc: any) => inc.id === item.id
-          );
-          let currentAmount: number;
-
-          if (isIncomeItem) {
-            const itemGrowthRate = (item.annual_growth_rate || 0) / 100;
-            currentAmount =
-              baseAmount * Math.pow(1 + itemGrowthRate, yearsFromStart);
-          } else {
-            const itemGrowthRate = (item.annual_growth_rate || 0) / 100;
-            const totalGrowthRate = inflationRate + itemGrowthRate;
-            currentAmount =
-              baseAmount * Math.pow(1 + totalGrowthRate, yearsFromStart);
-          }
-
-          row[item.id as string] = Math.round(currentAmount);
-        } else {
-          row[item.id as string] = 0;
-        }
+        row[item.id as string] = computeAnnualItemAmountAtAge(
+          item,
+          age,
+          inflationRatePct,
+          'positive'
+        );
       });
 
       data.push(row);
@@ -517,6 +491,17 @@ export function Stage2FinancialTable({
     [baseProjectionData, getItemIdFromColumn]
   );
 
+  const isColumnOverridden = useCallback(
+    (col: number): boolean => {
+      if (col < 1) return false;
+      const itemId = getItemIdFromColumn(col);
+      if (!itemId) return false;
+      const currentOverrides = usePlannerStore.getState().data.overrides || [];
+      return currentOverrides.some(override => override.item_id === itemId);
+    },
+    [getItemIdFromColumn]
+  );
+
   // 处理撤销 override
   const handleUndoOverride = useCallback(
     (row: number, col: number) => {
@@ -553,6 +538,19 @@ export function Stage2FinancialTable({
     ]
   );
 
+  const handleResetColumnOverrides = useCallback(
+    (col: number) => {
+      const itemId = getItemIdFromColumn(col);
+      if (!itemId) return;
+
+      removeOverridesByItemId(itemId);
+
+      // 重新渲染以更新样式，保持滚动位置
+      scheduleRender(true, 30);
+    },
+    [getItemIdFromColumn, removeOverridesByItemId, scheduleRender]
+  );
+
   // 创建 Handsontable
   useEffect(() => {
     if (!hotRef.current || tableData.length === 0) return;
@@ -568,6 +566,24 @@ export function Stage2FinancialTable({
       fixedColumnsLeft: 1, // 冻结首列（年份/年龄）
       contextMenu: {
         items: {
+          reset_column_overrides: {
+            name: t('table.context_menu.reset_column_overrides'),
+            callback: () => {
+              const selection = hotInstance.current?.getSelected();
+              if (selection) {
+                const [, col] = selection[0];
+                if (isColumnOverridden(col)) {
+                  handleResetColumnOverrides(col);
+                }
+              }
+            },
+            disabled: () => {
+              const selection = hotInstance.current?.getSelected();
+              if (!selection) return true;
+              const [, col] = selection[0];
+              return !isColumnOverridden(col);
+            },
+          },
           undo_override: {
             name: t('table.context_menu.undo_override'),
             callback: () => {
@@ -578,6 +594,12 @@ export function Stage2FinancialTable({
                   handleUndoOverride(row, col);
                 }
               }
+            },
+            disabled: () => {
+              const selection = hotInstance.current?.getSelected();
+              if (!selection) return true;
+              const [row, col] = selection[0];
+              return !isCellOverridden(row, col);
             },
           },
         },
@@ -875,11 +897,14 @@ export function Stage2FinancialTable({
     isColumnEditable,
     generateAutofillValues,
     isCellOverridden,
+    isColumnOverridden,
     handleUndoOverride,
+    handleResetColumnOverrides,
     getItemIdFromColumn,
     addOverride,
     updateOverride,
     removeOverride,
+    removeOverridesByItemId,
     scheduleRender,
   ]); // 包含所有必要的函数依赖
 

--- a/implementations/typescript/src/core/planner.ts
+++ b/implementations/typescript/src/core/planner.ts
@@ -412,74 +412,16 @@ export class FIREPlanner {
       let totalIncome = new Decimal(0);
       let totalExpense = new Decimal(0);
 
-      // Calculate income for this age
       for (const item of this.data.income_items) {
-        if (this._isItemActiveAtAge(item, age)) {
-          const yearsSinceStart = age - item.start_age;
-          const growthRate = new Decimal(item.annual_growth_rate).div(100);
-          const growthFactor = new Decimal(1)
-            .add(growthRate)
-            .pow(yearsSinceStart);
-
-          if (item.frequency === 'one-time') {
-            // One-time items only appear at start age
-            if (age === item.start_age) {
-              const amount = new Decimal(item.after_tax_amount_per_period).mul(
-                growthFactor
-              );
-              totalIncome = totalIncome.add(amount);
-            }
-          } else {
-            // Recurring items with growth
-            const amount = new Decimal(item.after_tax_amount_per_period).mul(
-              growthFactor
-            );
-            totalIncome = totalIncome.add(amount);
-          }
-        }
+        totalIncome = totalIncome.add(
+          this._calculateItemContributionAtAge(item, age)
+        );
       }
 
-      // Calculate expenses for this age (with inflation)
-      const inflationRate = new Decimal(profile.inflation_rate).div(100);
       for (const item of this.data.expense_items) {
-        if (this._isItemActiveAtAge(item, age)) {
-          const yearsSinceStart = age - item.start_age;
-
-          if (item.frequency === 'one-time') {
-            // One-time expenses only appear at start age
-            if (age === item.start_age) {
-              // Apply both individual growth rate and inflation
-              const itemGrowthRate = new Decimal(item.annual_growth_rate).div(
-                100
-              );
-              const itemGrowthFactor = new Decimal(1)
-                .add(itemGrowthRate)
-                .pow(yearsSinceStart);
-              const inflationFactor = new Decimal(1)
-                .add(inflationRate)
-                .pow(yearsSinceStart);
-              const amount = new Decimal(item.after_tax_amount_per_period)
-                .mul(itemGrowthFactor)
-                .mul(inflationFactor);
-              totalExpense = totalExpense.add(amount);
-            }
-          } else {
-            // Recurring expenses with individual growth + inflation
-            const itemGrowthRate = new Decimal(item.annual_growth_rate).div(
-              100
-            );
-            const itemGrowthFactor = new Decimal(1)
-              .add(itemGrowthRate)
-              .pow(yearsSinceStart);
-            const inflationFactor = new Decimal(1)
-              .add(inflationRate)
-              .pow(yearsSinceStart);
-            const amount = new Decimal(item.after_tax_amount_per_period)
-              .mul(itemGrowthFactor)
-              .mul(inflationFactor);
-            totalExpense = totalExpense.add(amount);
-          }
-        }
+        totalExpense = totalExpense.add(
+          this._calculateItemContributionAtAge(item, age)
+        );
       }
 
       projectionData.push({
@@ -491,6 +433,26 @@ export class FIREPlanner {
     }
 
     return projectionData;
+  }
+
+  private _countOccurrencesInYearByMonthInterval(
+    yearsSinceStart: number,
+    intervalMonths: number
+  ): number {
+    const monthsFromStart = yearsSinceStart * 12;
+    let count = 0;
+    for (let monthIndex = 0; monthIndex < 12; monthIndex++) {
+      if ((monthsFromStart + monthIndex) % intervalMonths === 0) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private _getTimeUnitMonths(timeUnit: IncomeExpenseItem['time_unit']): number {
+    if (timeUnit === 'monthly') return 1;
+    if (timeUnit === 'quarterly') return 3;
+    return 12;
   }
 
   /**
@@ -565,15 +527,27 @@ export class FIREPlanner {
     const growthFactor = new Decimal(1).add(growthRate).pow(yearsSinceStart);
 
     if (item.frequency === 'one-time') {
-      if (age === item.start_age) {
-        return new Decimal(item.after_tax_amount_per_period).mul(growthFactor);
-      } else {
-        return new Decimal(0);
-      }
+      if (age !== item.start_age) return new Decimal(0);
+
+      return new Decimal(item.after_tax_amount_per_period).mul(growthFactor);
     } else {
-      let contribution = new Decimal(item.after_tax_amount_per_period).mul(
-        growthFactor
+      const intervalPeriods = Math.max(
+        1,
+        Math.floor(item.interval_periods ?? 1)
       );
+
+      const intervalMonths =
+        intervalPeriods * this._getTimeUnitMonths(item.time_unit);
+      const periodsThisYear = this._countOccurrencesInYearByMonthInterval(
+        yearsSinceStart,
+        intervalMonths
+      );
+
+      if (periodsThisYear === 0) return new Decimal(0);
+
+      let contribution = new Decimal(item.after_tax_amount_per_period)
+        .mul(periodsThisYear)
+        .mul(growthFactor);
 
       // Apply inflation for expenses
       if (!item.is_income && this.data.user_profile) {

--- a/implementations/typescript/src/stores/plannerStore.ts
+++ b/implementations/typescript/src/stores/plannerStore.ts
@@ -82,6 +82,96 @@ const normalizePortfolioAssetClasses = (
   return normalized as any;
 };
 
+const normalizeIncomeExpenseItems = (
+  items: unknown,
+  isIncome: boolean
+): IncomeExpenseItem[] => {
+  const array = Array.isArray(items) ? items : [];
+
+  const toFiniteNumber = (raw: any, fallback = 0): number => {
+    const num = typeof raw === 'number' ? raw : Number(raw);
+    return Number.isFinite(num) ? num : fallback;
+  };
+
+  const toFiniteInt = (raw: any, fallback = 0): number => {
+    return Math.floor(toFiniteNumber(raw, fallback));
+  };
+
+  const normalizeTimeUnit = (raw: any): IncomeExpenseItem['time_unit'] => {
+    const value = String(raw ?? '');
+    if (value === 'monthly') return 'monthly';
+    if (value === 'quarterly') return 'quarterly';
+    if (value === 'annually') return 'annually';
+    if (value === 'annual' || value === 'yearly' || value === 'year')
+      return 'annually';
+    if (value === 'month') return 'monthly';
+    if (value === 'quarter') return 'quarterly';
+    return 'annually';
+  };
+
+  const normalizeFrequency = (raw: any): IncomeExpenseItem['frequency'] => {
+    const value = String(raw ?? '');
+    if (value === 'recurring') return 'recurring';
+    if (value === 'one-time' || value === 'one_time') return 'one-time';
+    if (value === 'annual' || value === 'monthly') return 'recurring';
+    return 'recurring';
+  };
+
+  const normalizeIntervalPeriods = (raw: any): number => {
+    const num = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isFinite(num)) return 1;
+    return Math.max(1, Math.floor(num));
+  };
+
+  return array.filter(Boolean).map((raw: any): IncomeExpenseItem => {
+    const normalizedFrequency = normalizeFrequency(raw?.frequency);
+    const inferredTimeUnit =
+      raw?.frequency === 'monthly'
+        ? 'monthly'
+        : raw?.frequency === 'annual'
+          ? 'annually'
+          : raw?.time_unit;
+
+    const timeUnit = normalizeTimeUnit(inferredTimeUnit);
+    const interval =
+      normalizedFrequency === 'one-time'
+        ? 1
+        : normalizeIntervalPeriods(raw?.interval_periods ?? raw?.interval);
+
+    const startAge = Math.max(0, toFiniteInt(raw?.start_age, 0));
+    const endAge =
+      raw?.end_age === undefined || raw?.end_age === null
+        ? undefined
+        : (() => {
+            const parsed = toFiniteNumber(raw.end_age, NaN);
+            return Number.isFinite(parsed)
+              ? Math.max(0, Math.floor(parsed))
+              : undefined;
+          })();
+
+    return {
+      id: typeof raw?.id === 'string' && raw.id.length > 0 ? raw.id : uuidv4(),
+      name: typeof raw?.name === 'string' ? raw.name : '',
+      after_tax_amount_per_period: toFiniteNumber(
+        raw?.after_tax_amount_per_period ?? raw?.amount,
+        0
+      ),
+      time_unit: timeUnit,
+      frequency: normalizedFrequency,
+      interval_periods: interval,
+      start_age: startAge,
+      end_age: endAge,
+      annual_growth_rate: toFiniteNumber(
+        raw?.annual_growth_rate ?? raw?.growth_rate,
+        0
+      ),
+      is_income: typeof raw?.is_income === 'boolean' ? raw.is_income : isIncome,
+      category: raw?.category,
+      predefined_type: raw?.predefined_type,
+    };
+  });
+};
+
 // =============================================================================
 // Initial State
 // =============================================================================
@@ -328,6 +418,23 @@ export const createPlannerStore = (config?: StoreConfig) => {
         }),
         false,
         'removeOverride'
+      );
+    },
+
+    removeOverridesByItemId: (itemId: string) => {
+      set(
+        state => ({
+          data: {
+            ...state.data,
+            overrides: state.data.overrides.filter(
+              override => override.item_id !== itemId
+            ),
+            updated_at: new Date().toISOString(),
+          },
+          isDirty: true,
+        }),
+        false,
+        'removeOverridesByItemId'
       );
     },
 
@@ -645,8 +752,14 @@ export const createPlannerStore = (config?: StoreConfig) => {
             data: {
               ...createInitialPlannerData(),
               user_profile: normalizedProfile,
-              income_items: config.income_items || [],
-              expense_items: config.expense_items || [],
+              income_items: normalizeIncomeExpenseItems(
+                config.income_items,
+                true
+              ),
+              expense_items: normalizeIncomeExpenseItems(
+                config.expense_items,
+                false
+              ),
               overrides: config.overrides || [],
               simulation_settings:
                 config.simulation_settings || DEFAULT_SIMULATION_SETTINGS,

--- a/implementations/typescript/src/stores/types.ts
+++ b/implementations/typescript/src/stores/types.ts
@@ -97,6 +97,7 @@ export interface PlannerActions {
   addOverride: (override: Override) => void;
   updateOverride: (index: number, override: Partial<Override>) => void;
   removeOverride: (index: number) => void;
+  removeOverridesByItemId: (itemId: string) => void;
   clearOverrides: () => void;
   cleanupOrphanedOverrides: () => void;
 

--- a/implementations/typescript/src/types/ui.ts
+++ b/implementations/typescript/src/types/ui.ts
@@ -14,6 +14,12 @@ export interface UIIncomeExpenseItem {
   name: string;
   after_tax_amount_per_period: number;
   frequency: UIItemFrequency;
+  /**
+   * Repeat interval in frequency unit periods.
+   * - `annual`: every N years
+   * - `monthly`: every N months
+   */
+  interval_periods: number;
   growth_rate: number;
   start_age: number;
   end_age: number;
@@ -35,11 +41,11 @@ export function convertUIToCore(
   if (item.frequency === 'annual') {
     time_unit = 'annually';
     frequency = 'recurring';
-    interval_periods = 1;
+    interval_periods = item.interval_periods ?? 1;
   } else if (item.frequency === 'monthly') {
     time_unit = 'monthly';
     frequency = 'recurring';
-    interval_periods = 1;
+    interval_periods = item.interval_periods ?? 1;
   } else {
     // one_time
     time_unit = 'annually';
@@ -53,7 +59,7 @@ export function convertUIToCore(
     after_tax_amount_per_period: item.after_tax_amount_per_period,
     time_unit,
     frequency,
-    interval_periods,
+    interval_periods: Math.max(1, Math.floor(interval_periods)),
     start_age: item.start_age,
     end_age: item.end_age,
     annual_growth_rate: item.growth_rate,
@@ -80,6 +86,7 @@ export function convertCoreToUI(item: IncomeExpenseItem): UIIncomeExpenseItem {
     name: item.name,
     after_tax_amount_per_period: item.after_tax_amount_per_period,
     frequency,
+    interval_periods: Math.max(1, Math.floor(item.interval_periods ?? 1)),
     growth_rate: item.annual_growth_rate,
     start_age: item.start_age,
     end_age: item.end_age || 100,

--- a/implementations/typescript/src/utils/projection.ts
+++ b/implementations/typescript/src/utils/projection.ts
@@ -1,0 +1,81 @@
+import type { IncomeExpenseItem } from '../types';
+
+type ExpenseSign = 'positive' | 'negative';
+
+const normalizePositiveInt = (value: unknown, fallback = 1): number => {
+  const num = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(num)) return fallback;
+  return Math.max(1, Math.floor(num));
+};
+
+const countOccurrencesInYearByMonthInterval = (
+  yearsSinceStart: number,
+  intervalMonths: number
+): number => {
+  const monthsFromStart = yearsSinceStart * 12;
+  let count = 0;
+  for (let monthIndex = 0; monthIndex < 12; monthIndex++) {
+    if ((monthsFromStart + monthIndex) % intervalMonths === 0) {
+      count++;
+    }
+  }
+  return count;
+};
+
+const getTimeUnitMonths = (
+  timeUnit: IncomeExpenseItem['time_unit']
+): number => {
+  if (timeUnit === 'monthly') return 1;
+  if (timeUnit === 'quarterly') return 3;
+  return 12;
+};
+
+/**
+ * Compute the (rounded) annual total contribution for an item at a specific age.
+ *
+ * - Respects `frequency`, `time_unit`, and `interval_periods`.
+ * - Applies `annual_growth_rate` for both income and expense items.
+ * - Applies `inflationRatePct` additionally for expense items.
+ */
+export const computeAnnualItemAmountAtAge = (
+  item: IncomeExpenseItem,
+  age: number,
+  inflationRatePct: number,
+  expenseSign: ExpenseSign = 'positive'
+): number => {
+  if (age < item.start_age) return 0;
+  if (item.end_age !== undefined && age > item.end_age) return 0;
+
+  const yearsSinceStart = age - item.start_age;
+  const intervalPeriods = normalizePositiveInt(item.interval_periods, 1);
+
+  let periodsThisYear = 0;
+  if (item.frequency === 'one-time') {
+    periodsThisYear = yearsSinceStart === 0 ? 1 : 0;
+  } else {
+    const intervalMonths = intervalPeriods * getTimeUnitMonths(item.time_unit);
+    periodsThisYear = countOccurrencesInYearByMonthInterval(
+      yearsSinceStart,
+      intervalMonths
+    );
+  }
+
+  if (periodsThisYear === 0) return 0;
+
+  const growthRate = (item.annual_growth_rate || 0) / 100;
+  const inflationRate = (inflationRatePct || 0) / 100;
+  const totalGrowthRate = item.is_income
+    ? growthRate
+    : growthRate + inflationRate;
+
+  const baseAnnualAmount =
+    (item.after_tax_amount_per_period || 0) * periodsThisYear;
+  const grownAmount =
+    baseAnnualAmount * Math.pow(1 + totalGrowthRate, yearsSinceStart);
+
+  const rounded = Math.round(grownAmount);
+  if (!item.is_income && expenseSign === 'negative') {
+    return -Math.abs(rounded);
+  }
+  return rounded;
+};

--- a/implementations/typescript/src/utils/validation.ts
+++ b/implementations/typescript/src/utils/validation.ts
@@ -367,6 +367,18 @@ export const validateIncomeExpenseItem = (
     });
   }
 
+  if (
+    item.frequency !== 'one-time' &&
+    item.time_unit === 'monthly' &&
+    !new Set([1, 2, 3, 4, 6]).has(item.interval_periods)
+  ) {
+    errors.push({
+      field: 'interval_periods',
+      message: 'For monthly items, interval must be one of 1, 2, 3, 4, 6',
+      code: 'INVALID_INTERVAL',
+    });
+  }
+
   // Growth rate validation (reasonable bounds)
   if (item.annual_growth_rate < -50 || item.annual_growth_rate > 100) {
     errors.push({

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -54,6 +54,7 @@
   "portfolio_expected_return": "Portfolio Expected Return",
   "weighted_average_return": "Weighted Average Expected Return",
   "weighted_average_return_help": "Overall portfolio expected return calculated based on asset class allocations and expected returns",
+  "portfolio_return_below_inflation_warning": "Portfolio expected return ({portfolioReturn}%) is below inflation ({inflationRate}%).",
   "liquidity_volatility": "Liquidity: {liquidity}, Volatility: {volatility}%",
   "income_items_header": "Income Items",
   "expense_items_header": "Expense Items",
@@ -61,6 +62,9 @@
   "item_name": "Name",
   "item_amount": "Amount",
   "item_frequency": "Frequency",
+  "item_interval": "Interval",
+  "interval_years": "years",
+  "interval_months": "months",
   "item_start_age": "Start Age",
   "item_end_age": "End Age",
   "item_growth_rate": "Growth Rate (%)",
@@ -336,6 +340,8 @@
   "validation": {
     "required": "This field is required",
     "must_be_positive": "Value must be positive",
+    "must_be_integer": "Value must be an integer",
+    "invalid_monthly_interval": "For monthly items, interval must be one of 1, 2, 3, 4, 6",
     "invalid_age": "Invalid age",
     "end_age_must_be_greater": "End age must be greater than start age",
     "please_fix_following_issues": "Please fix the following issues:",
@@ -416,6 +422,7 @@
     },
     "context_menu": {
       "undo_override": "🔄 Undo Override",
+      "reset_column_overrides": "♻️ Reset Column Overrides",
       "undo": "↶ Undo",
       "redo": "↷ Redo",
       "copy": "📋 Copy"

--- a/shared/i18n/ja.json
+++ b/shared/i18n/ja.json
@@ -54,6 +54,7 @@
   "portfolio_expected_return": "ポートフォリオ期待リターン",
   "weighted_average_return": "加重平均期待リターン",
   "weighted_average_return_help": "資産クラスの配分と期待リターンに基づいて計算された全体的なポートフォリオ期待リターン",
+  "portfolio_return_below_inflation_warning": "ポートフォリオ期待リターン（{portfolioReturn}%）がインフレ率（{inflationRate}%）を下回っています。",
   "liquidity_volatility": "流動性：{liquidity}、ボラティリティ：{volatility}%",
   "income_items_header": "収入項目",
   "expense_items_header": "支出項目",
@@ -61,6 +62,9 @@
   "item_name": "名前",
   "item_amount": "金額",
   "item_frequency": "頻度",
+  "item_interval": "間隔",
+  "interval_years": "年",
+  "interval_months": "ヶ月",
   "item_start_age": "開始年齢",
   "item_end_age": "終了年齢",
   "item_growth_rate": "成長率 (%)",
@@ -329,6 +333,8 @@
   "validation": {
     "required": "このフィールドは必須です",
     "must_be_positive": "値は正の数である必要があります",
+    "must_be_integer": "値は整数である必要があります",
+    "invalid_monthly_interval": "月次項目の間隔は 1、2、3、4、6 のいずれかである必要があります",
     "invalid_age": "無効な年齢",
     "end_age_must_be_greater": "終了年齢は開始年齢より大きい必要があります",
     "please_fix_following_issues": "以下の問題を修正してください：",
@@ -409,6 +415,7 @@
     },
     "context_menu": {
       "undo_override": "🔄 Override取消",
+      "reset_column_overrides": "♻️ この列のOverrideをリセット",
       "undo": "↶ 元に戻す",
       "redo": "↷ やり直し",
       "copy": "📋 コピー"

--- a/shared/i18n/zh-CN.json
+++ b/shared/i18n/zh-CN.json
@@ -54,6 +54,7 @@
   "portfolio_expected_return": "投资组合预期回报",
   "weighted_average_return": "加权平均预期回报",
   "weighted_average_return_help": "基于各资产类别配置比例和预期回报计算的整体组合预期回报",
+  "portfolio_return_below_inflation_warning": "投资组合预期回报（{portfolioReturn}%）低于通胀率（{inflationRate}%）。",
   "liquidity_volatility": "流动性：{liquidity}，波动性：{volatility}%",
   "income_items_header": "收入项目",
   "expense_items_header": "支出项目",
@@ -61,6 +62,9 @@
   "item_name": "名称",
   "item_amount": "金额",
   "item_frequency": "频率",
+  "item_interval": "间隔",
+  "interval_years": "年",
+  "interval_months": "个月",
   "item_start_age": "起始年龄",
   "item_end_age": "结束年龄",
   "item_growth_rate": "增长率 (%)",
@@ -329,6 +333,8 @@
   "validation": {
     "required": "此字段是必需的",
     "must_be_positive": "值必须为正数",
+    "must_be_integer": "值必须为整数",
+    "invalid_monthly_interval": "按月项目的间隔只能是 1、2、3、4、6",
     "invalid_age": "无效年龄",
     "end_age_must_be_greater": "结束年龄必须大于起始年龄",
     "please_fix_following_issues": "请修复以下问题：",
@@ -409,6 +415,7 @@
     },
     "context_menu": {
       "undo_override": "🔄 撤销Override",
+      "reset_column_overrides": "♻️ 重置本列Override",
       "undo": "↶ 撤销",
       "redo": "↷ 重做",
       "copy": "📋 复制"


### PR DESCRIPTION
- Stage1: expose interval_periods for recurring income/expense items; restrict monthly interval to 1/2/3/4/6

- Stage2: generate interval-aware projections for table/chart; add 'Reset Column Overrides' context menu

- Core: respect interval_periods in planner projection; add shared projection helper (monthly/quarterly/annual)

- Store/import: normalize legacy items (default interval_periods=1) and sanitize numeric fields; add removeOverridesByItemId

- UX/docs/i18n: warn when portfolio expected return < inflation; add new strings; mark Python impl as legacy; update AGENTS guidance