### PR TITLE
fix(ts): align projection_data naming

### DIFF
--- a/implementations/typescript/src/core/__tests__/engine.test.ts
+++ b/implementations/typescript/src/core/__tests__/engine.test.ts
@@ -97,7 +97,7 @@ describe('FIREEngine', () => {
   test('engine initialization', () => {
     expect(fireEngine.input).toBeDefined();
     expect(fireEngine.profile).toBeDefined();
-    expect(fireEngine.projection_df).toBeDefined();
+    expect(fireEngine.projection_data).toBeDefined();
     expect(fireEngine.portfolio_simulator).toBeDefined();
     // PortfolioSimulator should be self-contained with internal calculator
     expect(fireEngine.portfolio_simulator.calculator).toBeDefined();

--- a/implementations/typescript/src/core/__tests__/monte_carlo.test.ts
+++ b/implementations/typescript/src/core/__tests__/monte_carlo.test.ts
@@ -22,7 +22,6 @@ import { FinancialCrisisEvent } from '../black_swan_events';
 
 describe('MonteCarloSimulatorSetup', () => {
   let profile: UserProfile;
-  let projection_df: AnnualFinancialProjection[];
   let engine_input: EngineInput;
   let engine: FIREEngine;
 
@@ -46,8 +45,7 @@ describe('MonteCarloSimulatorSetup', () => {
       );
     }
 
-    projection_df = projection_data;
-    engine_input = createEngineInput(profile, projection_df);
+    engine_input = createEngineInput(profile, projection_data);
     engine = new FIREEngine(engine_input);
   });
 
@@ -89,7 +87,6 @@ describe('MonteCarloSimulatorSetup', () => {
 
 describe('BasicVariations', () => {
   let profile: UserProfile;
-  let projection_df: AnnualFinancialProjection[];
   let engine_input: EngineInput;
   let engine: FIREEngine;
   let settings: SimulationSettings;
@@ -114,8 +111,7 @@ describe('BasicVariations', () => {
       );
     }
 
-    projection_df = projection_data;
-    engine_input = createEngineInput(profile, projection_df);
+    engine_input = createEngineInput(profile, projection_data);
     engine = new FIREEngine(engine_input);
 
     // Settings without black swan events
@@ -219,7 +215,6 @@ describe('BasicVariations', () => {
 
 describe('BlackSwanEventApplication', () => {
   let profile: UserProfile;
-  let projection_df: AnnualFinancialProjection[];
   let engine_input: EngineInput;
   let engine: FIREEngine;
   let settings: SimulationSettings;
@@ -244,8 +239,7 @@ describe('BlackSwanEventApplication', () => {
       );
     }
 
-    projection_df = projection_data;
-    engine_input = createEngineInput(profile, projection_df);
+    engine_input = createEngineInput(profile, projection_data);
     engine = new FIREEngine(engine_input);
 
     // Settings with black swan events
@@ -411,8 +405,8 @@ describe('MonteCarloAnalysis', () => {
       inflation_rate: new Decimal(3.0),
       safety_buffer_months: new Decimal(12.0),
     });
-    const projection_df = [createProjectionRow(35, 2025, 100000, 50000)];
-    const engine_input = createEngineInput(profile, projection_df);
+    const projection_data = [createProjectionRow(35, 2025, 100000, 50000)];
+    const engine_input = createEngineInput(profile, projection_data);
     const engine = new FIREEngine(engine_input);
     simulator = new MonteCarloSimulator(engine);
   });
@@ -494,11 +488,11 @@ describe('SensitivityAnalysis', () => {
       inflation_rate: new Decimal(3.0),
       safety_buffer_months: new Decimal(12.0),
     });
-    const projection_df = [
+    const projection_data = [
       createProjectionRow(35, 2025, 100000, 50000),
       createProjectionRow(36, 2026, 100000, 50000),
     ];
-    const engine_input = createEngineInput(profile, projection_df);
+    const engine_input = createEngineInput(profile, projection_data);
     const engine = new FIREEngine(engine_input);
 
     const settings = createSimulationSettings({
@@ -581,11 +575,11 @@ describe('SeedReproducibility', () => {
       inflation_rate: new Decimal(3.0),
       safety_buffer_months: new Decimal(12.0),
     });
-    const projection_df = [
+    const projection_data = [
       createProjectionRow(35, 2025, 100000, 50000),
       createProjectionRow(36, 2026, 100000, 50000),
     ];
-    const engine_input = createEngineInput(profile, projection_df);
+    const engine_input = createEngineInput(profile, projection_data);
     engine = new FIREEngine(engine_input);
 
     settings = createSimulationSettings({
@@ -692,8 +686,7 @@ describe('MonteCarloIntegration', () => {
       );
     }
 
-    const projection_df = projection_data;
-    const engine_input = createEngineInput(profile, projection_df);
+    const engine_input = createEngineInput(profile, projection_data);
     engine = new FIREEngine(engine_input);
   });
 

--- a/implementations/typescript/src/core/__tests__/planner.test.ts
+++ b/implementations/typescript/src/core/__tests__/planner.test.ts
@@ -225,7 +225,7 @@ describe('FIREPlanner', () => {
       expect(projectionData[0]).toHaveProperty('year');
       expect(projectionData[0]).toHaveProperty('total_income');
       expect(projectionData[0]).toHaveProperty('total_expense');
-      expect(planner.data.projection_df).toBe(projectionData);
+      expect(planner.data.projection_data).toBe(projectionData);
     });
 
     test('generate projection table with missing data', () => {
@@ -520,14 +520,14 @@ describe('FIREPlanner', () => {
       planner.addExpenseItem(sampleExpenseItem);
       planner.generateProjectionTable();
 
-      expect(planner.data.projection_df).toBeDefined();
+      expect(planner.data.projection_data).toBeDefined();
 
       // Remove income item should clear projection if regeneration fails
       planner.data.user_profile = undefined; // Force regeneration to fail
       planner.removeIncomeItem('work-income');
 
       // Should have cleared projection due to error
-      expect(planner.data.projection_df).toBeUndefined();
+      expect(planner.data.projection_data).toBeUndefined();
     });
 
     test('override cleanup on profile change', () => {

--- a/implementations/typescript/src/core/__tests__/planner_models.test.ts
+++ b/implementations/typescript/src/core/__tests__/planner_models.test.ts
@@ -212,7 +212,7 @@ describe('PlannerModels', () => {
       expect(data.user_profile).toBeUndefined();
       expect(data.income_items).toEqual([]);
       expect(data.expense_items).toEqual([]);
-      expect(data.projection_df).toBeUndefined();
+      expect(data.projection_data).toBeUndefined();
       expect(data.overrides).toEqual([]);
       expect(data.results).toBeUndefined();
       expect(data.session_id).toMatch(/^[0-9a-f-]{36}$/); // UUID format
@@ -500,7 +500,7 @@ describe('PlannerModels', () => {
         user_profile: mockUserProfile,
         income_items: mockIncomeItems,
         expense_items: mockExpenseItems,
-        projection_df: projectionData,
+        projection_data: projectionData,
       });
 
       expect(isReadyForStage(stage2Data, PlannerStage.STAGE1_INPUT)).toBe(true);

--- a/implementations/typescript/src/core/advisor.ts
+++ b/implementations/typescript/src/core/advisor.ts
@@ -61,7 +61,7 @@ export class FIREAdvisor {
   public readonly engine_input: EngineInput;
   public readonly profile: UserProfile;
   public readonly projection_data: AnnualFinancialProjection[];
-  public readonly detailed_projection_df:
+  public readonly detailed_projection_data:
     | AnnualFinancialProjection[]
     | DetailedProjection[];
   public readonly income_items: IncomeExpenseItem[];
@@ -71,7 +71,9 @@ export class FIREAdvisor {
     this.engine_input = engine_input;
     this.profile = engine_input.user_profile;
     this.projection_data = engine_input.annual_financial_projection;
-    this.detailed_projection_df = [...engine_input.annual_financial_projection]; // Create a copy
+    this.detailed_projection_data = [
+      ...engine_input.annual_financial_projection,
+    ]; // Create a copy
     this.income_items = engine_input.income_items || [];
   }
 
@@ -464,7 +466,7 @@ export class FIREAdvisor {
     }
 
     // Create deep copy to avoid modifying original data
-    const extended_projection = this.detailed_projection_df.map(row => ({
+    const extended_projection = this.detailed_projection_data.map(row => ({
       ...row,
     }));
     const current_fire_age = this.profile.expected_fire_age;
@@ -519,7 +521,7 @@ export class FIREAdvisor {
     target_fire_age: number
   ): AnnualFinancialProjection[] {
     // Create deep copy to avoid modifying original data
-    const modified_projection = this.detailed_projection_df.map(row => ({
+    const modified_projection = this.detailed_projection_data.map(row => ({
       ...row,
     }));
     const current_age = getCurrentAgeAsOf(

--- a/implementations/typescript/src/core/advisor.ts
+++ b/implementations/typescript/src/core/advisor.ts
@@ -60,7 +60,7 @@ export interface SimpleRecommendation {
 export class FIREAdvisor {
   public readonly engine_input: EngineInput;
   public readonly profile: UserProfile;
-  public readonly projection_df: AnnualFinancialProjection[];
+  public readonly projection_data: AnnualFinancialProjection[];
   public readonly detailed_projection_df:
     | AnnualFinancialProjection[]
     | DetailedProjection[];
@@ -70,7 +70,7 @@ export class FIREAdvisor {
     // language parameter is deprecated but kept for backward compatibility
     this.engine_input = engine_input;
     this.profile = engine_input.user_profile;
-    this.projection_df = engine_input.annual_financial_projection;
+    this.projection_data = engine_input.annual_financial_projection;
     this.detailed_projection_df = [...engine_input.annual_financial_projection]; // Create a copy
     this.income_items = engine_input.income_items || [];
   }
@@ -345,7 +345,7 @@ export class FIREAdvisor {
     if (required_multiplier && required_multiplier.gt(new Decimal(1.001))) {
       // Calculate additional income needed (matching Python logic)
       const original_income =
-        this.projection_df[0]?.total_income || new Decimal(0);
+        this.projection_data[0]?.total_income || new Decimal(0);
       const additional_income = original_income.mul(
         required_multiplier.sub(new Decimal(1.0))
       );
@@ -408,7 +408,7 @@ export class FIREAdvisor {
       let original_expense = new Decimal(0);
 
       // Try to find first non-zero expense
-      for (const row of this.projection_df) {
+      for (const row of this.projection_data) {
         if (row.total_expense && row.total_expense.gt(0)) {
           original_expense = row.total_expense;
           break;
@@ -417,7 +417,7 @@ export class FIREAdvisor {
 
       // If still zero, calculate average expense from all non-zero rows
       if (original_expense.eq(0)) {
-        const nonZeroExpenses = this.projection_df
+        const nonZeroExpenses = this.projection_data
           .map(row => row.total_expense)
           .filter(exp => exp && exp.gt(0));
 
@@ -545,7 +545,7 @@ export class FIREAdvisor {
   private _apply_income_multiplier(
     multiplier: Decimal
   ): AnnualFinancialProjection[] {
-    return this.projection_df.map(row => ({
+    return this.projection_data.map(row => ({
       ...row,
       total_income: row.total_income.mul(multiplier),
       net_cash_flow: row.total_income.mul(multiplier).sub(row.total_expense),
@@ -558,7 +558,7 @@ export class FIREAdvisor {
   private _apply_expense_multiplier(
     multiplier: Decimal
   ): AnnualFinancialProjection[] {
-    return this.projection_df.map(row => ({
+    return this.projection_data.map(row => ({
       ...row,
       total_expense: row.total_expense.mul(multiplier),
       net_cash_flow: row.total_income.sub(row.total_expense.mul(multiplier)),

--- a/implementations/typescript/src/core/engine.ts
+++ b/implementations/typescript/src/core/engine.ts
@@ -75,13 +75,13 @@ export interface DetailedProjection {
 export class FIREEngine {
   public readonly input: EngineInput;
   public readonly profile: UserProfile;
-  public readonly projection_df: AnnualFinancialProjection[];
+  public readonly projection_data: AnnualFinancialProjection[];
   public readonly portfolio_simulator: PortfolioSimulator;
 
   constructor(engineInput: EngineInput) {
     this.input = engineInput;
     this.profile = engineInput.user_profile;
-    this.projection_df = engineInput.annual_financial_projection;
+    this.projection_data = engineInput.annual_financial_projection;
 
     // Set up portfolio simulator
     this.portfolio_simulator = new PortfolioSimulator(this.profile);
@@ -181,7 +181,7 @@ export class FIREEngine {
     this.portfolio_simulator.reset_to_initial();
 
     // Process each year atomically - DataFrame already has final computed values
-    for (const row of this.projection_df) {
+    for (const row of this.projection_data) {
       const yearly_state = this.calculate_single_year(
         row.age,
         row.year,

--- a/implementations/typescript/src/core/monte_carlo.ts
+++ b/implementations/typescript/src/core/monte_carlo.ts
@@ -119,7 +119,7 @@ export class MonteCarloSimulator {
         expense_base_volatility: new Decimal(0.05),
         expense_minimum_factor: new Decimal(0.5),
       });
-    this.base_df = [...engine.projection_df];
+    this.base_df = [...engine.projection_data];
     this.seed = seed || null;
     this._rng_state = seed || Date.now();
 

--- a/implementations/typescript/src/core/planner.ts
+++ b/implementations/typescript/src/core/planner.ts
@@ -112,12 +112,12 @@ export class FIREPlanner {
       this._removeOverridesForItem(itemId);
 
       // If we had a projection, try to regenerate it
-      if (this.data.projection_df) {
+      if (this.data.projection_data) {
         try {
-          this.data.projection_df = this._generateInitialProjection();
+          this.data.projection_data = this._generateInitialProjection();
         } catch (error) {
           // If regeneration fails, clear projection
-          this.data.projection_df = undefined;
+          this.data.projection_data = undefined;
         }
       }
 
@@ -139,12 +139,12 @@ export class FIREPlanner {
       this._removeOverridesForItem(itemId);
 
       // If we had a projection, try to regenerate it
-      if (this.data.projection_df) {
+      if (this.data.projection_data) {
         try {
-          this.data.projection_df = this._generateInitialProjection();
+          this.data.projection_data = this._generateInitialProjection();
         } catch (error) {
           // If regeneration fails, clear projection
-          this.data.projection_df = undefined;
+          this.data.projection_data = undefined;
         }
       }
 
@@ -162,12 +162,12 @@ export class FIREPlanner {
    * Get current projection DataFrame with overrides applied
    */
   getProjectionDataFrame(): AnnualProjectionRow[] | undefined {
-    if (!this.data.projection_df) {
+    if (!this.data.projection_data) {
       return undefined;
     }
 
     // Return projection with overrides applied for display
-    const displayData = [...this.data.projection_df];
+    const displayData = [...this.data.projection_data];
     this._applyOverridesToProjection(displayData);
     return displayData;
   }
@@ -244,7 +244,7 @@ export class FIREPlanner {
     progressCallback?: (progress: number) => void,
     numSimulations?: number
   ): Promise<PlannerResults> {
-    if (!this.data.projection_df) {
+    if (!this.data.projection_data) {
       throw new Error('No projection data available for calculation');
     }
 
@@ -282,7 +282,7 @@ export class FIREPlanner {
 
     // Generate and store base projection
     const projectionData = this._generateInitialProjection();
-    this.data.projection_df = projectionData;
+    this.data.projection_data = projectionData;
     this.data = updatePlannerDataTimestamp(this.data);
 
     return projectionData;
@@ -296,10 +296,10 @@ export class FIREPlanner {
     overrides?: Override[]
   ): AnnualProjectionRow[] {
     if (!baseData) {
-      if (!this.data.projection_df) {
+      if (!this.data.projection_data) {
         throw new Error('No base projection data available');
       }
-      baseData = this.data.projection_df;
+      baseData = this.data.projection_data;
     }
 
     if (!overrides) {
@@ -327,15 +327,15 @@ export class FIREPlanner {
     numSimulations?: number
   ): Promise<PlannerResults> {
     if (!projectionData) {
-      if (!this.data.projection_df) {
+      if (!this.data.projection_data) {
         throw new Error('No projection data available for calculation');
       }
-      projectionData = this.data.projection_df;
+      projectionData = this.data.projection_data;
     }
 
     // Store original projection temporarily
-    const originalProjection = this.data.projection_df;
-    this.data.projection_df = projectionData;
+    const originalProjection = this.data.projection_data;
+    this.data.projection_data = projectionData;
 
     const results = await this._runCalculations(
       progressCallback,
@@ -343,7 +343,7 @@ export class FIREPlanner {
     );
 
     // Restore original projection
-    this.data.projection_df = originalProjection;
+    this.data.projection_data = originalProjection;
 
     return results;
   }
@@ -571,12 +571,12 @@ export class FIREPlanner {
     progressCallback?: (progress: number) => void,
     numSimulations?: number
   ): Promise<PlannerResults> {
-    if (!this.data.projection_df || !this.data.user_profile) {
+    if (!this.data.projection_data || !this.data.user_profile) {
       throw new Error('Missing data for calculations');
     }
 
     // Create a copy of projection and apply overrides for calculation
-    const calculationData = [...this.data.projection_df];
+    const calculationData = [...this.data.projection_data];
     this._applyOverridesToProjection(calculationData);
 
     // Create engine input - convert AnnualProjectionRow to AnnualFinancialProjection

--- a/implementations/typescript/src/core/planner_models.ts
+++ b/implementations/typescript/src/core/planner_models.ts
@@ -167,7 +167,7 @@ export interface PlannerData {
 
   // Stage 2: Adjustments
   /** Financial projection data as array of annual rows */
-  projection_df?: AnnualProjectionRow[];
+  projection_data?: AnnualProjectionRow[];
 
   /** User overrides for specific ages/items */
   overrides: Override[];
@@ -229,7 +229,7 @@ export function createPlannerData(
     user_profile: data.user_profile,
     income_items: data.income_items ?? [],
     expense_items: data.expense_items ?? [],
-    projection_df: data.projection_df,
+    projection_data: data.projection_data,
     overrides: data.overrides ?? [],
     results: data.results,
     session_id: data.session_id ?? generateUUID(),
@@ -494,8 +494,8 @@ export function isReadyForStage(
     case PlannerStage.STAGE3_ANALYSIS:
       return (
         isReadyForStage(data, PlannerStage.STAGE2_ADJUSTMENT) &&
-        data.projection_df !== undefined &&
-        data.projection_df.length > 0
+        data.projection_data !== undefined &&
+        data.projection_data.length > 0
       );
 
     default:

--- a/implementations/typescript/src/core/portfolio.ts
+++ b/implementations/typescript/src/core/portfolio.ts
@@ -539,7 +539,7 @@ export class LiquidityAwareFlowStrategy implements CashFlowStrategy {
   ): void {
     const investmentTargets: Record<string, Decimal> = {};
     Object.entries(targetAllocation).forEach(([k, v]) => {
-      if (k !== 'Cash') {
+      if (k !== 'cash') {
         investmentTargets[k] = v;
       }
     });

--- a/implementations/typescript/src/services/fireCalculationService.ts
+++ b/implementations/typescript/src/services/fireCalculationService.ts
@@ -141,13 +141,13 @@ export class FIRECalculationService {
           plannerData.simulation_settings.income_base_volatility ?? 0.1
         ),
         income_minimum_factor: new Decimal(
-          plannerData.simulation_settings.income_minimum_factor ?? 0.5
+          plannerData.simulation_settings.income_minimum_factor ?? 0.1
         ),
         expense_base_volatility: new Decimal(
           plannerData.simulation_settings.expense_base_volatility ?? 0.05
         ),
         expense_minimum_factor: new Decimal(
-          plannerData.simulation_settings.expense_minimum_factor ?? 0.8
+          plannerData.simulation_settings.expense_minimum_factor ?? 0.5
         ),
       };
 
@@ -249,7 +249,7 @@ export class FIRECalculationService {
         expense_items: convertedExpenseItems,
         overrides: convertedOverrides,
         user_profile: convertedUserProfile,
-        projection_df: convertedProjectionData,
+        projection_data: convertedProjectionData,
       };
     } catch (error) {
       console.error('❌ 数据转换失败:', error);
@@ -264,7 +264,7 @@ export class FIRECalculationService {
     planner.data = convertedData;
 
     // If Stage2 didn't provide a final table, fall back to generating one from items.
-    if (!planner.data.projection_df) {
+    if (!planner.data.projection_data) {
       planner.generateProjectionTable();
     }
 


### PR DESCRIPTION
Summary:\n- Rename TypeScript core fields from projection_df to projection_data to match planner store + docs.\n- Update service/core model wiring and tests accordingly.\n- Align FIRECalculationService fallback defaults for income_minimum_factor/expense_minimum_factor with DEFAULT_SIMULATION_SETTINGS (0.1 / 0.5).\n\nNotes:\n- Potential breaking change only if external code depends on TS core properties named projection_df/detailed_projection_df; internal app uses projection_data.